### PR TITLE
fix(schedule): update league schedule endpoint

### DIFF
--- a/.agents/skills/add-missing-odds-data/SKILL.md
+++ b/.agents/skills/add-missing-odds-data/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: nba-odds-scraper
+description: >
+  Scrape NBA game odds from DraftKings (via ESPN's DraftKings odds page and supplementary sources) and generate SQL INSERT statements for the bronze.draftkings_game_odds table. Use this skill whenever the user asks to pull NBA odds, scrape DraftKings lines, generate odds INSERT statements, load game odds into the database, or anything related to collecting NBA spread/moneyline/total data for games on a given date. Also trigger when the user mentions "odds inserts", "DraftKings odds", "game lines", or "pull odds for today's games".
+---
+
+# NBA Odds Scraper
+
+This skill collects NBA game odds from DraftKings and produces SQL INSERT statements targeting the `bronze.draftkings_game_odds` table.
+
+## Target Table DDL
+
+```sql
+CREATE TABLE bronze.draftkings_game_odds (
+    team text NULL,
+    spread text NULL,
+    total text NULL,
+    moneyline float8 NULL,
+    "date" date NULL,
+    datetime1 timestamp NULL,
+    scrape_ts timestamp NULL,
+    created_at timestamp DEFAULT CURRENT_TIMESTAMP NULL,
+    modified_at timestamp DEFAULT CURRENT_TIMESTAMP NULL,
+    CONSTRAINT unique_constraint_for_upsert_aws_odds_source UNIQUE (team, date),
+    CONSTRAINT unique_constraint_for_upsert_draftkings_game_odds UNIQUE (team, date),
+    CONSTRAINT unique_constraint_for_upsert_odds UNIQUE (team, date)
+);
+```
+
+## Workflow
+
+### Step 1: Identify the games
+
+The user will provide either:
+- A date and ask you to pull all NBA games for that date, OR
+- A specific list of games (possibly via pasted schedule data)
+
+If the user provides schedule data, extract all unique matchups from it. Each game produces **two rows** (one per team).
+
+### Step 2: Search for DraftKings odds
+
+The primary source is the **ESPN NBA Odds page** which displays DraftKings lines:
+- Search: `ESPN NBA odds DraftKings [date]`
+- Fetch: `https://www.espn.com/nba/odds`
+
+The ESPN odds page contains DraftKings spread, total, and moneyline for each game. Parse the data carefully — the format from ESPN is dense and interleaved.
+
+**How to read the ESPN odds page output:**
+
+Each game block follows this pattern:
+```
+[datetime]OpenSpreadTotalML
+[Away Team][Abbrev] · (record) · [open spread] · [spread juice] · [current spread] · [spread juice] · [over total] · [over juice] · [moneyline]
+[Home Team][Abbrev] · (record) · [open spread or total] · [juice] · [current spread] · [spread juice] · [under total] · [under juice] · [moneyline]
+```
+
+Example:
+```
+Boston CelticsCelticsBOS · (42-21) · -1.5 · EVEN · +1.5 · -120 · o223.5 · -115 · -105
+Cleveland CavaliersCavaliersCLE · (39-24) · u225.5 · -110 · -1.5 · EVEN · u223.5 · -105 · -115
+```
+
+This means:
+- BOS: spread +1.5, moneyline -105
+- CLE: spread -1.5, moneyline -115
+- Total: 223.5 (use the current total, not the opening total)
+
+If ESPN data is incomplete or stale (check that the dates match), supplement with targeted searches:
+- `[Team1] [Team2] odds spread moneyline DraftKings [date]`
+- Sources like CBS Sports, FanDuel Research, SportsBettingDime, and Covers often report DraftKings lines explicitly
+
+Prioritize DraftKings-sourced lines. If DraftKings-specific data isn't available for a game, use the consensus line (BetMGM, FanDuel lines are usually within 0.5-1 point) and note this to the user.
+
+### Step 3: Generate INSERT statements
+
+Produce a single INSERT statement with all rows. Follow these formatting rules exactly:
+
+#### Column mappings:
+
+| Column | Value | Example |
+|--------|-------|---------|
+| `team` | 3-letter uppercase NBA acronym | `'BOS'` |
+| `spread` | Signed spread as text, favorite is negative | `'+1.5'`, `'-5.5'` |
+| `total` | Over/under number as text, no prefix characters | `'223.5'` |
+| `moneyline` | American odds as float, "EVEN" = 100 | `-105`, `100` |
+| `date` | Game date in YYYY-MM-DD | `'2026-03-08'` |
+| `datetime1` | Game tip-off timestamp in ET | `'2026-03-08 13:00:00'` |
+| `scrape_ts` | Use `NOW()` | `NOW()` |
+
+#### Team acronyms:
+
+Use standard NBA abbreviations:
+```
+ATL, BOS, BKN, CHA, CHI, CLE, DAL, DEN, DET, GSW,
+HOU, IND, LAC, LAL, MEM, MIA, MIL, MIN, NOP, NYK,
+OKC, ORL, PHI, PHX, POR, SAC, SAS, TOR, UTA, WAS
+```
+
+#### Key rules:
+
+1. **Two rows per game** — one for each team
+2. **`total` column** — Both teams in a game get the same total value (just the number, no `o`/`u` prefix). Example: `'223.5'`
+3. **`spread` column** — The favorite gets a negative spread, the underdog gets a positive spread. Always include the sign. Example: `'-3.5'`, `'+3.5'`
+4. **`moneyline` column** — Use American odds as a number. Convert "EVEN" to `100`. Favorites are negative, underdogs are positive.
+5. **`datetime1`** — Use Eastern Time for all game times
+6. **Comment each game** with `-- AWAY @ HOME (time ET)` for readability
+7. **Sort games chronologically** by tip-off time
+
+#### Output template:
+
+```sql
+INSERT INTO bronze.draftkings_game_odds (team, spread, total, moneyline, date, datetime1, scrape_ts)
+VALUES
+-- BOS @ CLE (1:00 PM ET)
+('BOS', '+1.5', '223.5', -105, '2026-03-08', '2026-03-08 13:00:00', NOW()),
+('CLE', '-1.5', '223.5', -115, '2026-03-08', '2026-03-08 13:00:00', NOW()),
+
+-- NYK @ LAL (3:30 PM ET)
+('NYK', '-3.5', '226.5', -148, '2026-03-08', '2026-03-08 15:30:00', NOW()),
+('LAL', '+3.5', '226.5', 124, '2026-03-08', '2026-03-08 15:30:00', NOW());
+```
+
+### Step 4: Present to user
+
+After generating the SQL, present it directly in the chat. If there are any games where DraftKings-specific odds were unavailable, note which games used alternative sportsbook sources.
+
+## Common pitfalls
+
+- The ESPN odds page sometimes shows cached/old data from a different date. Always verify the dates in the ESPN response match the requested date. If stale, rely on individual game searches.
+- ESPN times are in UTC (e.g., `2026-03-08T17:00Z` = 1:00 PM ET). Convert to ET for the `datetime1` column.
+- "EVEN" moneyline means +100 or -100 depending on context. Default to `100`.
+- Some games may not have odds posted yet if they're far in the future. Let the user know.
+- The total is the same number for both teams in a matchup — do not differentiate over/under in the `total` column.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ great_expectations
 logs/
 odds-local.csv
 src/*.csv
+.codex

--- a/.opencode.json
+++ b/.opencode.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "skills": {
+        "paths": [
+            ".agents/skills/add-missing-odds-data"
+        ]
+    }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md
+
+## Repo Shape
+
+- Python ingestion project for NBA ELT data.
+- Core runtime code lives in `src/`.
+- Scraper entry points live in `src/scrapers.py` as `get_*_data` functions.
+- Database bootstrap and test compose files live in `docker/`.
+- Tests live in `tests/unit` and `tests/integration`, with shared fixtures in `tests/conftest.py` and `tests/fixtures`.
+
+## Feature Flags
+
+Feature flags are database-backed and are loaded once before the scraper calls run.
+
+- `src/app.py` creates a SQLAlchemy engine from `RDS_*` environment variables.
+- `FeatureFlagManager.load(engine=engine)` reads `gold.feature_flags`.
+- `src/feature_flags.py` stores flags in the class-level `FeatureFlagManager._flags` dict, keyed by `flag`.
+- `FeatureFlagManager.get(flag)` returns the integer `is_enabled` value, or `None` when the flag has not been loaded/found.
+
+Most scraper functions are wrapped with `@check_feature_flag_decorator(flag_name="...")` from `src/decorators.py`.
+The wrapper checks `FeatureFlagManager` at call time:
+
+- missing flag: raise `ValueError`;
+- disabled flag (`0`/falsey): log and return an empty `pd.DataFrame`;
+- enabled flag (`1`/truthy): execute the scraper normally.
+
+When adding a new scraper, add the flag to `gold.feature_flags` in `docker/postgres_bootstrap.sql`, decorate the scraper function, and make sure tests load the flag through the normal fixture path.
+
+The `season` and `playoffs` flags are also read directly in `src/app.py` to build `schedule_months_to_pull` via `generate_schedule_pull_type`.
+
+## Tests
+
+Use the Docker-backed flow when possible:
+
+```bash
+make test
+```
+
+This runs `docker/docker-compose-test.yml`, starts a real `postgres:16-alpine` container, bootstraps it with `docker/postgres_bootstrap.sql`, then runs pytest inside the `ingestion_script_test_runner` container.
+
+For local pytest against a Docker Postgres container:
+
+```bash
+make ci-test
+```
+
+`make ci-test` starts the Postgres service, runs:
+
+```bash
+uv run --frozen pytest -vv --cov-report term --cov-report xml:coverage.xml --cov=src --color=yes
+```
+
+and then stops the container.
+
+`tests/conftest.py` is important:
+
+- it blocks real internet sockets, so tests should use fixtures/mocks instead of live network calls;
+- it creates a SQLAlchemy engine pointed at Docker Postgres;
+- the session-scoped `load_feature_flags` fixture calls `FeatureFlagManager.load(engine=postgres_conn)`;
+- scraper fixtures patch HTTP calls and feed data from `tests/fixtures`.
+
+Integration tests are real database integration tests, not pure mocks. Keep schema assumptions aligned with `docker/postgres_bootstrap.sql`.
+
+## Working Notes
+
+- Prefer extending existing scraper/decorator patterns over introducing new orchestration paths.
+- Keep scraper outputs as `pd.DataFrame` objects; disabled scrapers should continue to produce empty frames through the decorator.
+- Do not bypass `FeatureFlagManager` in scraper code unless the caller truly needs direct flag semantics like the schedule month selection does.
+- If a test needs feature flags, update the bootstrap SQL instead of manually mutating `FeatureFlagManager._flags` in integration coverage.

--- a/src/utils.py
+++ b/src/utils.py
@@ -76,7 +76,7 @@ def check_schedule(date: datetime.date) -> bool:
     Returns:
         Boolean: True if there are games scheduled, False if not.
     """
-    schedule_endpoint = f"https://api.jyablonski.dev/schedule?date={date}"
+    schedule_endpoint = f"https://api.jyablonski.dev/v1/league/schedule?date={date}"
     schedule_data = requests.get(schedule_endpoint).json()
 
     return len(schedule_data) > 0

--- a/tests/integration/check_schedule_test.py
+++ b/tests/integration/check_schedule_test.py
@@ -37,6 +37,10 @@ from src.utils import check_schedule
     ],
 )
 def test_check_schedule(mocker: MockerFixture, date, mock_input, expected):
-    mocker.patch("src.utils.requests.get").return_value.json.return_value = mock_input
+    mock_get = mocker.patch("src.utils.requests.get")
+    mock_get.return_value.json.return_value = mock_input
     is_games_played = check_schedule(date=date)
+    mock_get.assert_called_once_with(
+        f"https://api.jyablonski.dev/v1/league/schedule?date={date}"
+    )
     assert is_games_played == expected


### PR DESCRIPTION
### Description
Updates the schedule checker to use the versioned league schedule API endpoint and adds coverage for the expected request URL.

## Added
- Agent guidance and NBA odds scraper skill configuration
- Opencode skill path configuration

## Updated
- Schedule checker endpoint to /v1/league/schedule
- Check schedule test to assert the versioned API URL
- Backfill script usage and target table names