### PR TITLE
fix(schedule): skip missing month pages

### DIFF
--- a/src/scrapers.py
+++ b/src/scrapers.py
@@ -1062,6 +1062,11 @@ def get_schedule_data(
                 f"Schedule scrape completed for {month}, {len(month_df)} rows retrieved"
             )
 
+        except HTTPError as error:
+            if error.code == 404:
+                logging.info(f"{month} schedule page not found, skipping.")
+                continue
+            raise
         except (IndexError, ValueError):
             logging.info(f"{month} has no data, skipping.")
 

--- a/tests/unit/scrapers/league_schedule_scraper_test.py
+++ b/tests/unit/scrapers/league_schedule_scraper_test.py
@@ -1,3 +1,10 @@
+from urllib.error import HTTPError
+
+import pandas as pd
+
+from src.scrapers import get_schedule_data
+
+
 def test_league_schedule_data(schedule_data):
     expected_columns = [
         "date",
@@ -9,3 +16,33 @@ def test_league_schedule_data(schedule_data):
 
     assert list(schedule_data.columns) == expected_columns
     assert len(schedule_data) == 0
+
+
+def test_league_schedule_skips_missing_month_page(mocker):
+    schedule_month = pd.DataFrame(
+        {
+            "Date": ["Mon, Apr 20, 2026"],
+            "Start (ET)": ["7:00p"],
+            "Visitor/Neutral": ["Boston Celtics"],
+            "Home/Neutral": ["New York Knicks"],
+        }
+    )
+    missing_month = HTTPError(
+        url="https://www.basketball-reference.com/leagues/NBA_2026_games-june.html",
+        code=404,
+        msg="Not Found",
+        hdrs=None,
+        fp=None,
+    )
+    mocker.patch(
+        "src.scrapers.pd.read_html",
+        side_effect=[[schedule_month], missing_month],
+    )
+
+    schedule = get_schedule_data(
+        month_list=["april", "june"],
+        include_past_games=True,
+    )
+
+    assert len(schedule) == 1
+    assert schedule.iloc[0]["away_team"] == "Boston Celtics"


### PR DESCRIPTION
### Description
Handle missing Basketball Reference schedule month pages so unavailable future playoff months do not fail the full schedule scrape.

## Added
- Regression coverage for a missing schedule month page after a successful month scrape

## Updated
- Skip 404 schedule month pages while continuing to process available months

## Deleted
- None