### PR TITLE
chore(ingestion): suppress pbp slack alert on no-data days

### DIFF
--- a/src/scrapers.py
+++ b/src/scrapers.py
@@ -822,8 +822,8 @@ def get_pbp_data(df: pd.DataFrame) -> pd.DataFrame:
         game_date = df["date"][0]
     else:
         df = pd.DataFrame()
-        logging.warning(
-            "PBP Transformation Function Failed, "
+        logging.info(
+            "PBP Transformation Function Skipped, "
             f"no data available for {datetime.now().date()}"
         )
         return df
@@ -985,8 +985,8 @@ def get_pbp_data(df: pd.DataFrame) -> pd.DataFrame:
                 return pd.DataFrame()
         else:
             df = pd.DataFrame()
-            logging.error(
-                f"PBP Transformation Function Failed, no data available for {game_date}"
+            logging.info(
+                f"PBP Transformation Function Skipped, no data available for {game_date}"
             )
             return df
     except Exception as error:


### PR DESCRIPTION
### Description
Stop the PBP ingestion function from firing a Slack alert on days with no games. The alerting picks up any log line containing "Failed", so the expected no-data branches were generating false alerts.

## Updated
- Reworded both "no data available" log messages in `get_pbp_data` from "Failed" to "Skipped" and downgraded them to `info` level, so they no longer trip `query_logs` / the Slack alert. Genuine failures still log at `error` level and alert as before.